### PR TITLE
Fix Bundle cache for CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -7,7 +7,7 @@ bundle_cache: &bundle_cache
       - cat Gemfile.lock
   install_script:
     - gem install bundler
-    - bundle update
+    - bundle install
 
 node_modules_cache: &node_modules_cache
   node_modules_cache:


### PR DESCRIPTION
We have `Gemfile.lock` in the repository, so run `install` instead of `update`.